### PR TITLE
feat: implements basic sessions crud operations

### DIFF
--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod game_system;
 pub mod jwt;
 pub mod password;
+pub mod session;
 pub mod table;
 pub mod table_request;
 pub mod user;

--- a/src/domain/session/commands.rs
+++ b/src/domain/session/commands.rs
@@ -1,0 +1,75 @@
+use crate::domain::{
+    session::filters::SessionFilters,
+    utils::{pagination::Pagination, update::Update},
+};
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct CreateSessionCommand {
+    pub table_id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub accepting_intents: bool,
+}
+
+impl CreateSessionCommand {
+    pub fn new(table_id: Uuid, name: String, description: String, accepting_intents: bool) -> Self {
+        Self {
+            table_id,
+            name,
+            description,
+            accepting_intents,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct GetSessionCommand {
+    pub filters: SessionFilters,
+    pub pagination: Pagination,
+}
+
+impl GetSessionCommand {
+    pub fn with_filters(self, filters: SessionFilters) -> Self {
+        Self { filters, ..self }
+    }
+
+    pub fn with_pagination(self, pagination: Pagination) -> Self {
+        Self { pagination, ..self }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateSessionCommand {
+    pub id: Uuid,
+    pub name: Update<String>,
+    pub description: Update<String>,
+    pub accepting_intents: Update<bool>,
+}
+
+impl UpdateSessionCommand {
+    pub fn new(
+        id: Uuid,
+        name: Update<String>,
+        description: Update<String>,
+        accepting_intents: Update<bool>,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            description,
+            accepting_intents,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DeleteSessionCommand {
+    pub id: Uuid,
+}
+
+impl DeleteSessionCommand {
+    pub fn new(id: Uuid) -> Self {
+        Self { id }
+    }
+}

--- a/src/domain/session/entity.rs
+++ b/src/domain/session/entity.rs
@@ -1,0 +1,14 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct Session {
+    pub id: Uuid,
+    pub table_id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub accepting_intents: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}

--- a/src/domain/session/filters.rs
+++ b/src/domain/session/filters.rs
@@ -1,0 +1,50 @@
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Default)]
+pub struct SessionFilters {
+    pub id: Option<Uuid>,
+    pub table_id: Option<Uuid>,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub accepting_intents: Option<bool>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+impl SessionFilters {
+    pub fn with_id(mut self, id: Uuid) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn with_table_id(mut self, table_id: Uuid) -> Self {
+        self.table_id = Some(table_id);
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> Self {
+        self.description = Some(description);
+        self
+    }
+
+    pub fn with_accepting_intents(mut self, accepting_intents: bool) -> Self {
+        self.accepting_intents = Some(accepting_intents);
+        self
+    }
+
+    pub fn with_created_at(mut self, created_at: DateTime<Utc>) -> Self {
+        self.created_at = Some(created_at);
+        self
+    }
+
+    pub fn with_updated_at(mut self, updated_at: DateTime<Utc>) -> Self {
+        self.updated_at = Some(updated_at);
+        self
+    }
+}

--- a/src/domain/session/mod.rs
+++ b/src/domain/session/mod.rs
@@ -1,0 +1,12 @@
+pub mod commands;
+pub mod entity;
+pub mod filters;
+pub mod repository;
+pub mod services;
+
+pub use commands::{
+    CreateSessionCommand, DeleteSessionCommand, GetSessionCommand, UpdateSessionCommand,
+};
+pub use entity::Session;
+pub use repository::SessionRepository;
+pub use services::SessionService;

--- a/src/domain/session/repository.rs
+++ b/src/domain/session/repository.rs
@@ -1,0 +1,17 @@
+use crate::Result;
+use crate::domain::session::entity::Session;
+use uuid::Uuid;
+
+use crate::domain::session::{
+    CreateSessionCommand, DeleteSessionCommand, GetSessionCommand, UpdateSessionCommand,
+};
+
+#[async_trait::async_trait]
+pub trait SessionRepository: Send + Sync {
+    async fn create(&self, session: &CreateSessionCommand) -> Result<Session>;
+    async fn get(&self, command: &GetSessionCommand) -> Result<Vec<Session>>;
+    async fn find_by_id(&self, id: &Uuid) -> Result<Option<Session>>;
+    async fn find_by_table_id(&self, table_id: &Uuid) -> Result<Vec<Session>>;
+    async fn update(&self, command: &UpdateSessionCommand) -> Result<Session>;
+    async fn delete(&self, command: &DeleteSessionCommand) -> Result<Session>;
+}

--- a/src/domain/session/services.rs
+++ b/src/domain/session/services.rs
@@ -1,0 +1,16 @@
+use crate::Result;
+use crate::domain::session::Session;
+use crate::domain::session::{
+    CreateSessionCommand, DeleteSessionCommand, GetSessionCommand, UpdateSessionCommand,
+};
+use uuid::Uuid;
+
+#[async_trait::async_trait]
+pub trait SessionService: Send + Sync {
+    async fn create(&self, command: &CreateSessionCommand) -> Result<Session>;
+    async fn get(&self, command: &GetSessionCommand) -> Result<Vec<Session>>;
+    async fn find_by_id(&self, id: &Uuid) -> Result<Session>;
+    async fn find_by_table_id(&self, table_id: &Uuid) -> Result<Vec<Session>>;
+    async fn update(&self, command: &UpdateSessionCommand) -> Result<Session>;
+    async fn delete(&self, command: &DeleteSessionCommand) -> Result<Session>;
+}

--- a/src/infrastructure/entities/mod.rs
+++ b/src/infrastructure/entities/mod.rs
@@ -8,3 +8,13 @@ pub mod t_session_intents;
 pub mod t_sessions;
 pub mod t_table_requests;
 pub mod t_users;
+
+pub use t_game_system::Model as GameSystemModel;
+pub use t_rpg_tables::Model as TableModel;
+pub use t_session_checkins::Model as SessionCheckinModel;
+pub use t_session_intents::Model as SessionIntentModel;
+pub use t_sessions::Model as SessionModel;
+pub use t_table_requests::Model as TableRequestModel;
+pub use t_users::Model as UserModel;
+
+pub use enums::*;

--- a/src/infrastructure/entities/t_sessions.rs
+++ b/src/infrastructure/entities/t_sessions.rs
@@ -1,12 +1,29 @@
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
+use crate::domain::session::Session;
+
 #[derive(Clone, Debug, PartialEq, Eq, sqlx::FromRow)]
 pub struct Model {
     pub id: Uuid,
     pub name: String,
+    pub description: String,
     pub table_id: Uuid,
     pub accepting_intents: bool,
     pub created_at: DateTime<Utc>,
-    pub updated_at: Option<DateTime<Utc>>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<Model> for Session {
+    fn from(model: Model) -> Self {
+        Session {
+            id: model.id,
+            table_id: model.table_id,
+            name: model.name,
+            description: model.description,
+            accepting_intents: model.accepting_intents,
+            created_at: model.created_at,
+            updated_at: model.updated_at,
+        }
+    }
 }

--- a/src/infrastructure/prelude.rs
+++ b/src/infrastructure/prelude.rs
@@ -2,7 +2,7 @@ pub use super::repositories::error::RepositoryError;
 pub use super::repositories::game_system::PostgresGameSystemRepository;
 pub use super::repositories::jwt::JwtTokenProvider;
 pub use super::repositories::password::Argon2PasswordProvider;
-pub use super::repositories::session::SessionRepository;
+pub use super::repositories::session::PostgresSessionRepository;
 pub use super::repositories::table::PostgresTableRepository;
 pub use super::repositories::table_request::PostgresTableRequestRepository;
 pub use super::repositories::user::PostgresUserRepository;

--- a/src/infrastructure/repositories/constraint_mapper.rs
+++ b/src/infrastructure/repositories/constraint_mapper.rs
@@ -1,40 +1,72 @@
 use crate::infrastructure::repositories::error::RepositoryError;
 use sqlx::Error as SqlxError;
+use sqlx::error::DatabaseError;
 
 const UNIQUE_CONSTRAINT_CODE: &str = "23505";
 const FOREIGN_KEY_CONSTRAINT_CODE: &str = "23503";
 
-pub fn map_constraint_violation(error: &SqlxError, constraint: &str) -> RepositoryError {
-    let db_err = error
-        .as_database_error()
-        .expect("Expected a database error");
+pub fn map_constraint_violation(db_err: &dyn DatabaseError, constraint: &str) -> RepositoryError {
     let message = db_err.message();
     let is_referenced_not_found = message.contains("is not present in table");
 
+    let extract_field_from_error = |field: &str| -> Option<String> {
+        let pattern = format!("Key ({field})=(");
+        if let Some(pos) = message.find(&pattern) {
+            let after = &message[pos + pattern.len()..];
+            if let Some(end) = after.find(')') {
+                let value = after[..end]
+                    .trim()
+                    .trim_matches(|c| c == '\'' || c == '"')
+                    .to_string();
+                if !value.is_empty() {
+                    return Some(value);
+                }
+            }
+        }
+
+        let alt_pattern = format!("({field})=(");
+        if let Some(pos) = message.find(&alt_pattern) {
+            let after = &message[pos + alt_pattern.len()..];
+            if let Some(end) = after.find(')') {
+                let value = after[..end]
+                    .trim()
+                    .trim_matches(|c| c == '\'' || c == '"')
+                    .to_string();
+                if !value.is_empty() {
+                    return Some(value);
+                }
+            }
+        }
+        None
+    };
+
     match constraint {
+        // Unique constraints
         "t_users_username_key" => {
-            tracing::error!("username already taken: {}", message);
+            tracing::debug!("Username already taken: {}", message);
             RepositoryError::UsernameAlreadyTaken
         }
         "t_users_email_key" => {
-            tracing::error!("email already taken: {}", message);
+            tracing::debug!("Email already taken: {}", message);
             RepositoryError::EmailAlreadyTaken
         }
         "t_game_system_name_key" => {
-            tracing::error!("game system name already taken: {}", message);
+            tracing::debug!("Game system name already taken: {}", message);
             RepositoryError::GameSystemNameAlreadyTaken
         }
         "t_session_intents_user_id_session_id_key" => {
-            tracing::error!("user session intent already exists: {}", message);
+            tracing::debug!("User session intent already exists: {}", message);
             RepositoryError::UserSessionIntentAlreadyExists
         }
 
+        // Foreign key constraints
         "t_rpg_tables_gm_id_fkey" => {
             if is_referenced_not_found {
-                let id = extract_field_from_error(error, "gm_id")
-                    .unwrap_or_else(|| "unknown".to_string());
+                tracing::debug!("User not found for gm_id: {}", message);
+                let id = extract_field_from_error("gm_id").unwrap_or_else(|| "unknown".to_string());
                 RepositoryError::UserNotFound(id)
             } else {
+                tracing::warn!("Foreign key violation for gm_id: {}", message);
                 RepositoryError::ForeignKeyViolation {
                     table: "t_rpg_tables".to_string(),
                     field: "gm_id".to_string(),
@@ -43,10 +75,12 @@ pub fn map_constraint_violation(error: &SqlxError, constraint: &str) -> Reposito
         }
         "t_rpg_tables_game_system_id_fkey" => {
             if is_referenced_not_found {
-                let id = extract_field_from_error(error, "game_system_id")
+                tracing::debug!("Game system not found: {}", message);
+                let id = extract_field_from_error("game_system_id")
                     .unwrap_or_else(|| "unknown".to_string());
                 RepositoryError::GameSystemNotFound(id)
             } else {
+                tracing::warn!("Foreign key violation for game_system_id: {}", message);
                 RepositoryError::ForeignKeyViolation {
                     table: "t_rpg_tables".to_string(),
                     field: "game_system_id".to_string(),
@@ -55,10 +89,12 @@ pub fn map_constraint_violation(error: &SqlxError, constraint: &str) -> Reposito
         }
         "t_sessions_table_id_fkey" => {
             if is_referenced_not_found {
-                let id = extract_field_from_error(error, "table_id")
-                    .unwrap_or_else(|| "unknown".to_string());
+                tracing::debug!("RPG table not found: {}", message);
+                let id =
+                    extract_field_from_error("table_id").unwrap_or_else(|| "unknown".to_string());
                 RepositoryError::RpgTableNotFound(id)
             } else {
+                tracing::warn!("Foreign key violation for table_id: {}", message);
                 RepositoryError::ForeignKeyViolation {
                     table: "t_sessions".to_string(),
                     field: "table_id".to_string(),
@@ -67,10 +103,15 @@ pub fn map_constraint_violation(error: &SqlxError, constraint: &str) -> Reposito
         }
         "t_session_intents_user_id_fkey" => {
             if is_referenced_not_found {
-                let id = extract_field_from_error(error, "user_id")
-                    .unwrap_or_else(|| "unknown".to_string());
+                tracing::debug!("User not found for session intent: {}", message);
+                let id =
+                    extract_field_from_error("user_id").unwrap_or_else(|| "unknown".to_string());
                 RepositoryError::UserNotFound(id)
             } else {
+                tracing::warn!(
+                    "Foreign key violation for user_id in session intents: {}",
+                    message
+                );
                 RepositoryError::ForeignKeyViolation {
                     table: "t_session_intents".to_string(),
                     field: "user_id".to_string(),
@@ -79,10 +120,10 @@ pub fn map_constraint_violation(error: &SqlxError, constraint: &str) -> Reposito
         }
         "t_session_intents_session_id_fkey" => {
             if is_referenced_not_found {
-                let id = extract_field_from_error(error, "session_id")
-                    .unwrap_or_else(|| "unknown".to_string());
-                RepositoryError::SessionNotFound(id)
+                tracing::debug!("Session not found: {}", message);
+                RepositoryError::SessionNotFound
             } else {
+                tracing::warn!("Foreign key violation for session_id: {}", message);
                 RepositoryError::ForeignKeyViolation {
                     table: "t_session_intents".to_string(),
                     field: "session_id".to_string(),
@@ -91,10 +132,12 @@ pub fn map_constraint_violation(error: &SqlxError, constraint: &str) -> Reposito
         }
         "t_session_checkins_session_intent_id_fkey" => {
             if is_referenced_not_found {
-                let id = extract_field_from_error(error, "session_intent_id")
+                tracing::debug!("Session intent not found: {}", message);
+                let id = extract_field_from_error("session_intent_id")
                     .unwrap_or_else(|| "unknown".to_string());
                 RepositoryError::SessionIntentNotFound(id)
             } else {
+                tracing::warn!("Foreign key violation for session_intent_id: {}", message);
                 RepositoryError::ForeignKeyViolation {
                     table: "t_session_checkins".to_string(),
                     field: "session_intent_id".to_string(),
@@ -103,86 +146,78 @@ pub fn map_constraint_violation(error: &SqlxError, constraint: &str) -> Reposito
         }
         "t_table_requests_user_id_fkey" => {
             if is_referenced_not_found {
-                let id = extract_field_from_error(error, "user_id")
-                    .unwrap_or_else(|| "unknown".to_string());
+                tracing::debug!("User not found for table request: {}", message);
+                let id =
+                    extract_field_from_error("user_id").unwrap_or_else(|| "unknown".to_string());
                 RepositoryError::UserNotFound(id)
             } else {
+                tracing::warn!(
+                    "Foreign key violation for user_id in table requests: {}",
+                    message
+                );
                 RepositoryError::ForeignKeyViolation {
                     table: "t_table_requests".to_string(),
                     field: "user_id".to_string(),
                 }
             }
         }
+        "t_table_requests_table_id_fkey" => {
+            if is_referenced_not_found {
+                tracing::debug!("RPG table not found for table request: {}", message);
+                let id =
+                    extract_field_from_error("table_id").unwrap_or_else(|| "unknown".to_string());
+                RepositoryError::RpgTableNotFound(id)
+            } else {
+                tracing::warn!(
+                    "Foreign key violation for table_id in table requests: {}",
+                    message
+                );
+                RepositoryError::ForeignKeyViolation {
+                    table: "t_table_requests".to_string(),
+                    field: "table_id".to_string(),
+                }
+            }
+        }
         _ => {
-            tracing::error!("unknown constraint violation: {}", constraint);
+            tracing::error!("Unknown constraint violation: {} - {}", constraint, message);
             RepositoryError::UnknownConstraint(constraint.to_string())
         }
     }
 }
 
-fn parse_key_value_from_text(text: &str, field: &str) -> Option<String> {
-    if let Some(pos) = text.find(&format!("({field})=(")) {
-        let after = &text[pos + field.len() + 4..];
-        if let Some(end) = after.find(')') {
-            let mut value = &after[..end];
-
-            value = value.trim_matches('\"').trim_matches('\'');
-            if !value.is_empty() {
-                return Some(value.to_string());
-            }
-        }
-    }
-
-    if let Some(pos) = text.find(&format!("({field})=")) {
-        let mut after = &text[pos + field.len() + 3..];
-        after = after.trim_start();
-        if after.starts_with('(') {
-            after = &after[1..];
-        }
-        if let Some(end) = after.find(|c: char| c == ')' || c.is_whitespace() || c == ',') {
-            let mut value = &after[..end];
-            value = value.trim_matches('\"').trim_matches('\'');
-            if !value.is_empty() {
-                return Some(value.to_string());
-            }
-        }
-    }
-
-    None
-}
-
-fn extract_field_from_error(error: &SqlxError, field: &str) -> Option<String> {
-    if let Some(db_err) = error.as_database_error() {
-        let message = db_err.message();
-        if let Some(val) = parse_key_value_from_text(message, field) {
-            return Some(val);
-        }
-    }
-
-    let error_display = error.to_string();
-    if let Some(val) = parse_key_value_from_text(&error_display, field) {
-        return Some(val);
-    }
-
-    None
-}
-
 pub fn map_database_error(error: SqlxError) -> RepositoryError {
-    if matches!(&error, SqlxError::RowNotFound) {
-        return RepositoryError::TableNotFound;
+    match error {
+        SqlxError::RowNotFound => RepositoryError::NotFound,
+        SqlxError::Database(db_err) => {
+            if let Some(code) = db_err.code() {
+                match code.as_ref() {
+                    UNIQUE_CONSTRAINT_CODE | FOREIGN_KEY_CONSTRAINT_CODE => {
+                        if let Some(constraint) = db_err.constraint() {
+                            tracing::debug!(
+                                "Mapping constraint violation: {} (code: {})",
+                                constraint,
+                                code
+                            );
+                            return map_constraint_violation(&*db_err, constraint);
+                        }
+                    }
+                    "23514" => {
+                        tracing::warn!("Check constraint violation: {}", db_err.message());
+                        return RepositoryError::ValidationError(db_err.message().to_string());
+                    }
+                    "22P02" => {
+                        tracing::warn!("Invalid input value: {}", db_err.message());
+                        return RepositoryError::InvalidInput(db_err.message().to_string());
+                    }
+                    _ => {}
+                }
+            }
+            tracing::error!("Unhandled database error: {:?}", db_err);
+            RepositoryError::DatabaseError(SqlxError::Database(db_err))
+        }
+        _ => {
+            tracing::error!("Unhandled general sqlx error: {:?}", error);
+            RepositoryError::DatabaseError(error)
+        }
     }
-
-    if let Some(db_err) = error.as_database_error()
-        && let Some(code) = db_err.code()
-        && (code == UNIQUE_CONSTRAINT_CODE || code == FOREIGN_KEY_CONSTRAINT_CODE)
-        && let Some(constraint) = db_err.constraint()
-    {
-        tracing::debug!(
-            "Mapping constraint violation: {} -> {:?}",
-            constraint,
-            error
-        );
-        return map_constraint_violation(&error, constraint);
-    }
-    RepositoryError::DatabaseError(error)
 }

--- a/src/infrastructure/repositories/error.rs
+++ b/src/infrastructure/repositories/error.rs
@@ -2,6 +2,10 @@ use crate::Error;
 
 #[derive(Debug, thiserror::Error)]
 pub enum RepositoryError {
+    #[error("Io error: {0}")]
+    IoError(String),
+    #[error("database timeout")]
+    DatabaseTimeout,
     #[error("username already taken")]
     UsernameAlreadyTaken,
     #[error("email already taken")]
@@ -24,12 +28,18 @@ pub enum RepositoryError {
     TableNotFound,
     #[error("table request not found")]
     TableRequestNotFound,
-    #[error("session not found: {0}")]
-    SessionNotFound(String),
+    #[error("session not found")]
+    SessionNotFound,
     #[error("session intent not found: {0}")]
     SessionIntentNotFound(String),
     #[error("unknown constraint: {0}")]
     UnknownConstraint(String),
+    #[error("not found")]
+    NotFound,
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+    #[error("validation error: {0}")]
+    ValidationError(String),
 }
 
 impl From<RepositoryError> for Error {

--- a/src/infrastructure/repositories/prelude.rs
+++ b/src/infrastructure/repositories/prelude.rs
@@ -2,7 +2,7 @@ pub use super::error::RepositoryError;
 pub use super::game_system::PostgresGameSystemRepository;
 pub use super::jwt::JwtTokenProvider;
 pub use super::password::Argon2PasswordProvider;
-pub use super::session::SessionRepository;
+pub use super::session::PostgresSessionRepository;
 pub use super::table::PostgresTableRepository;
 pub use super::table_request::PostgresTableRequestRepository;
 pub use super::user::PostgresUserRepository;

--- a/src/infrastructure/repositories/session.rs
+++ b/src/infrastructure/repositories/session.rs
@@ -1,1 +1,230 @@
-pub struct SessionRepository;
+use crate::Result;
+use crate::domain::session::{
+    CreateSessionCommand, DeleteSessionCommand, GetSessionCommand, Session, SessionRepository,
+    UpdateSessionCommand,
+};
+use crate::domain::utils::update::Update;
+use crate::infrastructure::entities::SessionModel;
+use crate::infrastructure::repositories::constraint_mapper;
+use chrono::Utc;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub struct PostgresSessionRepository {
+    pool: Arc<PgPool>,
+}
+
+impl PostgresSessionRepository {
+    pub fn new(pool: Arc<PgPool>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl SessionRepository for PostgresSessionRepository {
+    async fn create(&self, session: &CreateSessionCommand) -> Result<Session> {
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+
+        let created_session = sqlx::query_as!(
+            SessionModel,
+            r#"INSERT INTO t_sessions
+                (id,
+                table_id,
+                name,
+                description,
+                accepting_intents,
+                created_at,
+                updated_at)
+            VALUES
+                ($1,
+                $2,
+                $3,
+                $4,
+                $5,
+                $6,
+                $7)
+            RETURNING
+                id,
+                table_id,
+                name,
+                description,
+                accepting_intents,
+                created_at,
+                updated_at
+            "#,
+            id,
+            session.table_id,
+            session.name,
+            session.description,
+            session.accepting_intents,
+            now,
+            now
+        )
+        .fetch_one(self.pool.as_ref())
+        .await
+        .map_err(constraint_mapper::map_database_error)?;
+
+        Ok(created_session.into())
+    }
+
+    async fn get(&self, command: &GetSessionCommand) -> Result<Vec<Session>> {
+        let mut builder = sqlx::QueryBuilder::new(r#"SELECT * FROM t_sessions "#);
+
+        let mut has_where = false;
+
+        let mut push_filter_separator = |b: &mut sqlx::QueryBuilder<'_, sqlx::Postgres>| {
+            if !has_where {
+                b.push(" WHERE ");
+                has_where = true;
+            } else {
+                b.push(" AND ");
+            }
+        };
+
+        if let Some(id) = &command.filters.id {
+            push_filter_separator(&mut builder);
+            builder.push("id = ");
+            builder.push_bind(id);
+        }
+
+        if let Some(name) = &command.filters.name {
+            push_filter_separator(&mut builder);
+            builder.push("name = ");
+            builder.push_bind(name);
+        }
+
+        if let Some(description) = &command.filters.description {
+            push_filter_separator(&mut builder);
+            builder.push("description = ");
+            builder.push_bind(description);
+        }
+
+        if let Some(accepting_intents) = &command.filters.accepting_intents {
+            push_filter_separator(&mut builder);
+            builder.push("accepting_intents = ");
+            builder.push_bind(accepting_intents);
+        }
+
+        if let Some(table_id) = &command.filters.table_id {
+            push_filter_separator(&mut builder);
+            builder.push("table_id = ");
+            builder.push_bind(table_id);
+        }
+
+        if let Some(created_at) = &command.filters.created_at {
+            push_filter_separator(&mut builder);
+            builder.push("created_at = ");
+            builder.push_bind(created_at);
+        }
+
+        if let Some(updated_at) = &command.filters.updated_at {
+            push_filter_separator(&mut builder);
+            builder.push("updated_at = ");
+            builder.push_bind(updated_at);
+        }
+
+        let page = command.pagination.limit();
+        let offset = command.pagination.offset();
+
+        builder.push(" LIMIT ");
+        builder.push_bind(page as i64);
+
+        builder.push(" OFFSET ");
+        builder.push_bind(offset as i64);
+
+        let sessions = builder
+            .build_query_as::<SessionModel>()
+            .fetch_all(self.pool.as_ref())
+            .await
+            .map_err(constraint_mapper::map_database_error)?;
+
+        Ok(sessions.into_iter().map(|s| s.into()).collect())
+    }
+
+    async fn find_by_id(&self, id: &Uuid) -> Result<Option<Session>> {
+        let session: Option<Session> = sqlx::query_as!(
+            SessionModel,
+            r#"SELECT
+                *
+            FROM t_sessions
+            WHERE id = $1"#,
+            id
+        )
+        .fetch_optional(self.pool.as_ref())
+        .await
+        .map_err(constraint_mapper::map_database_error)?
+        .and_then(|session| Some(Session::from(session)));
+
+        Ok(session)
+    }
+
+    async fn find_by_table_id(&self, table_id: &Uuid) -> Result<Vec<Session>> {
+        let sessions = sqlx::query_as!(
+            SessionModel,
+            r#"SELECT
+                *
+            FROM t_sessions
+            WHERE table_id = $1"#,
+            table_id
+        )
+        .fetch_all(self.pool.as_ref())
+        .await
+        .map_err(constraint_mapper::map_database_error)?;
+
+        Ok(sessions.into_iter().map(|s| s.into()).collect())
+    }
+
+    async fn update(&self, command: &UpdateSessionCommand) -> Result<Session> {
+        let now = Utc::now();
+        let mut builder = sqlx::QueryBuilder::new("UPDATE t_sessions SET ");
+        let mut separated = builder.separated(", ");
+
+        if let Update::Change(name) = &command.name {
+            separated.push("name = ");
+            separated.push_bind_unseparated(name);
+        }
+
+        if let Update::Change(description) = &command.description {
+            separated.push("description = ");
+            separated.push_bind_unseparated(description);
+        }
+
+        if let Update::Change(accepting_intents) = &command.accepting_intents {
+            separated.push(" accepting_intents = ");
+            separated.push_bind_unseparated(accepting_intents);
+        }
+
+        separated.push(" updated_at = ");
+        separated.push_bind_unseparated(now);
+
+        builder.push(" WHERE id = ");
+        builder.push_bind(command.id);
+
+        builder.push(r#" RETURNING *"#);
+
+        let updated_table = builder
+            .build_query_as::<SessionModel>()
+            .fetch_one(self.pool.as_ref())
+            .await
+            .map_err(constraint_mapper::map_database_error)?;
+
+        Ok(updated_table.into())
+    }
+
+    async fn delete(&self, command: &DeleteSessionCommand) -> Result<Session> {
+        let session = sqlx::query_as!(
+            SessionModel,
+            r#"DELETE FROM t_sessions
+            WHERE id = $1
+            RETURNING *"#,
+            command.id
+        )
+        .fetch_one(self.pool.as_ref())
+        .await
+        .map_err(constraint_mapper::map_database_error)?;
+
+        Ok(session.into())
+    }
+}

--- a/src/infrastructure/repositories/session.rs
+++ b/src/infrastructure/repositories/session.rs
@@ -155,7 +155,7 @@ impl SessionRepository for PostgresSessionRepository {
         .fetch_optional(self.pool.as_ref())
         .await
         .map_err(constraint_mapper::map_database_error)?
-        .and_then(|session| Some(Session::from(session)));
+        .map(Session::from);
 
         Ok(session)
     }

--- a/src/infrastructure/repositories/table.rs
+++ b/src/infrastructure/repositories/table.rs
@@ -34,17 +34,17 @@ impl TableRepositoryTrait for PostgresTableRepository {
 
         let created_table = sqlx::query_as!(
             TableModel,
-            r#"INSERT INTO t_rpg_tables 
-                (id, 
-                gm_id, 
-                title, 
-                visibility, 
-                description, 
-                game_system_id, 
-                player_slots, 
-                created_at, 
+            r#"INSERT INTO t_rpg_tables
+                (id,
+                gm_id,
+                title,
+                visibility,
+                description,
+                game_system_id,
+                player_slots,
+                created_at,
                 updated_at)
-            VALUES 
+            VALUES
                 ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             RETURNING
                 id,
@@ -113,12 +113,12 @@ impl TableRepositoryTrait for PostgresTableRepository {
         builder.push_bind(command.id);
 
         builder.push(
-            r#" RETURNING 
-                id, 
-                gm_id, 
-                title, 
+            r#" RETURNING
+                id,
+                gm_id,
+                title,
                 visibility,
-                description, 
+                description,
                 game_system_id,
                 player_slots,
                 created_at,
@@ -137,7 +137,7 @@ impl TableRepositoryTrait for PostgresTableRepository {
     async fn delete(&self, command: &DeleteTableCommand) -> Result<Table> {
         let table = sqlx::query_as!(
             TableModel,
-            r#"DELETE FROM t_rpg_tables 
+            r#"DELETE FROM t_rpg_tables
                 WHERE id = $1
                 RETURNING
                     id,
@@ -166,16 +166,16 @@ impl TableRepositoryTrait for PostgresTableRepository {
 
     async fn get(&self, command: &GetTableCommand) -> Result<Vec<Table>> {
         let mut builder = sqlx::QueryBuilder::new(
-            r#"SELECT 
-                id, 
-                gm_id, 
-                title, 
-                visibility, 
-                description, 
-                game_system_id, 
-                player_slots, 
-                created_at, 
-                updated_at 
+            r#"SELECT
+                id,
+                gm_id,
+                title,
+                visibility,
+                description,
+                game_system_id,
+                player_slots,
+                created_at,
+                updated_at
             FROM t_rpg_tables"#,
         );
 
@@ -264,17 +264,17 @@ impl TableRepositoryTrait for PostgresTableRepository {
     async fn find_by_id(&self, table_id: &Uuid) -> Result<Table> {
         let table = sqlx::query_as!(
             TableModel,
-            r#"SELECT 
-                id, 
-                gm_id, 
-                title, 
-                visibility as "visibility: ETableVisibility", 
-                description, 
-                game_system_id, 
-                player_slots, 
-                created_at, 
-                updated_at 
-            FROM t_rpg_tables 
+            r#"SELECT
+                id,
+                gm_id,
+                title,
+                visibility as "visibility: ETableVisibility",
+                description,
+                game_system_id,
+                player_slots,
+                created_at,
+                updated_at
+            FROM t_rpg_tables
             WHERE id = $1"#,
             table_id
         )
@@ -291,16 +291,16 @@ impl TableRepositoryTrait for PostgresTableRepository {
     async fn find_by_gm_id(&self, gm_id: &Uuid) -> Result<Vec<Table>> {
         let tables = sqlx::query_as!(
             TableModel,
-            r#"SELECT 
-                id, 
-                gm_id, 
-                title, 
-                visibility as "visibility: ETableVisibility", 
-                description, 
-                game_system_id, 
-                player_slots, 
-                created_at, 
-                updated_at 
+            r#"SELECT
+                id,
+                gm_id,
+                title,
+                visibility as "visibility: ETableVisibility",
+                description,
+                game_system_id,
+                player_slots,
+                created_at,
+                updated_at
             FROM t_rpg_tables
             WHERE gm_id = $1"#,
             gm_id
@@ -312,6 +312,3 @@ impl TableRepositoryTrait for PostgresTableRepository {
         Ok(tables.into_iter().map(|m| m.into()).collect())
     }
 }
-
-#[cfg(test)]
-mod tests {}

--- a/tests/session_repository_test.rs
+++ b/tests/session_repository_test.rs
@@ -1,0 +1,670 @@
+mod utils;
+
+use jos::Error;
+use jos::domain::session::filters::SessionFilters;
+use jos::domain::session::{
+    CreateSessionCommand, DeleteSessionCommand, GetSessionCommand, SessionRepository,
+    UpdateSessionCommand,
+};
+use jos::domain::table::commands::CreateTableCommand;
+use jos::domain::table::entity::Visibility;
+use jos::domain::table::table_repository::TableRepository;
+use jos::domain::utils::pagination::Pagination;
+use jos::domain::utils::update::Update;
+use jos::infrastructure::prelude::{PostgresSessionRepository, PostgresTableRepository};
+use jos::infrastructure::repositories::error::RepositoryError;
+use sqlx::PgPool;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[sqlx::test]
+async fn test_create_session_success(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table for RPG".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data = CreateSessionCommand::new(
+        table.id,
+        "Test Session".to_string(),
+        "A test session".to_string(),
+        true,
+    );
+
+    let result = session_repo.create(&session_data).await;
+
+    match result {
+        Ok(session) => {
+            assert_eq!(session.name, "Test Session");
+            assert_eq!(session.description, "A test session".to_string());
+            assert_eq!(session.accepting_intents, true);
+            assert_eq!(session.table_id, table.id);
+            assert!(session.id != Uuid::nil());
+        }
+        Err(e) => {
+            panic!("Unexpected error: {e:?}");
+        }
+    }
+}
+
+#[sqlx::test]
+async fn test_create_session_accepting_intents_false(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table for RPG".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data = CreateSessionCommand::new(
+        table.id,
+        "Closed Session".to_string(),
+        "A closed test session".to_string(),
+        false,
+    );
+
+    let result = session_repo.create(&session_data).await;
+
+    match result {
+        Ok(session) => {
+            assert_eq!(session.name, "Closed Session");
+            assert_eq!(session.accepting_intents, false);
+        }
+        Err(e) => {
+            panic!("Unexpected error: {e:?}");
+        }
+    }
+}
+
+#[sqlx::test]
+async fn test_find_by_id(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table for RPG".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data = CreateSessionCommand::new(
+        table.id,
+        "Test Session".to_string(),
+        "A test session".to_string(),
+        true,
+    );
+
+    let created_session = session_repo.create(&session_data).await.unwrap();
+    let found_session = session_repo.find_by_id(&created_session.id).await.unwrap();
+
+    match found_session {
+        Some(session) => {
+            assert_eq!(session.id, created_session.id);
+            assert_eq!(session.name, "Test Session");
+            assert_eq!(session.description, "A test session".to_string());
+            assert_eq!(session.accepting_intents, true);
+        }
+        None => panic!("Session not found"),
+    }
+}
+
+#[sqlx::test]
+async fn test_find_by_id_not_found(pool: PgPool) {
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+
+    let random_id = Uuid::new_v4();
+    let result = session_repo.find_by_id(&random_id).await.unwrap();
+
+    match result {
+        Some(session) => panic!("Unexpected session found: {session:?}"),
+        None => {}
+    }
+}
+
+#[sqlx::test]
+async fn test_find_by_table_id(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table for RPG".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data1 = CreateSessionCommand::new(
+        table.id,
+        "Session 1".to_string(),
+        "First session".to_string(),
+        true,
+    );
+
+    let session_data2 = CreateSessionCommand::new(
+        table.id,
+        "Session 2".to_string(),
+        "Second session".to_string(),
+        false,
+    );
+
+    session_repo.create(&session_data1).await.unwrap();
+    session_repo.create(&session_data2).await.unwrap();
+
+    let found_sessions = session_repo.find_by_table_id(&table.id).await.unwrap();
+    assert_eq!(found_sessions.len(), 2);
+
+    let names: Vec<String> = found_sessions.iter().map(|s| s.name.clone()).collect();
+    assert!(names.contains(&"Session 1".to_string()));
+    assert!(names.contains(&"Session 2".to_string()));
+}
+
+#[sqlx::test]
+async fn test_find_by_table_id_empty(pool: PgPool) {
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool));
+    let random_table_id = Uuid::new_v4();
+
+    let found_sessions = session_repo
+        .find_by_table_id(&random_table_id)
+        .await
+        .unwrap();
+    assert_eq!(found_sessions.len(), 0);
+}
+
+#[sqlx::test]
+async fn test_get_all_sessions(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm1 = utils::create_user(&pool).await;
+    let gm2 = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data1 = CreateTableCommand::new(
+        gm1.id,
+        "Table 1".into(),
+        "First table".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+
+    let table_data2 = CreateTableCommand::new(
+        gm2.id,
+        "Table 2".into(),
+        "Second table".into(),
+        Visibility::Public,
+        3,
+        game_system.id,
+    );
+
+    let table1 = table_repo.create(&table_data1).await.unwrap();
+    let table2 = table_repo.create(&table_data2).await.unwrap();
+
+    let session_data1 = CreateSessionCommand::new(
+        table1.id,
+        "Session 1".to_string(),
+        "First session".to_string(),
+        true,
+    );
+
+    let session_data2 = CreateSessionCommand::new(
+        table2.id,
+        "Session 2".to_string(),
+        "Second session".to_string(),
+        false,
+    );
+
+    session_repo.create(&session_data1).await.unwrap();
+    session_repo.create(&session_data2).await.unwrap();
+
+    let get_command = GetSessionCommand::default();
+    let all_sessions = session_repo.get(&get_command).await.unwrap();
+    assert_eq!(all_sessions.len(), 2);
+
+    let names: Vec<String> = all_sessions.iter().map(|s| s.name.clone()).collect();
+    assert!(names.contains(&"Session 1".to_string()));
+    assert!(names.contains(&"Session 2".to_string()));
+}
+
+#[sqlx::test]
+async fn test_get_sessions_with_filters(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data1 = CreateSessionCommand {
+        table_id: table.id,
+        name: "Open Session".to_string(),
+        description: "Open session".to_string(),
+        accepting_intents: true,
+    };
+
+    let session_data2 = CreateSessionCommand {
+        table_id: table.id,
+        name: "Closed Session".to_string(),
+        description: "Closed session".to_string(),
+        accepting_intents: false,
+    };
+
+    session_repo.create(&session_data1).await.unwrap();
+    session_repo.create(&session_data2).await.unwrap();
+
+    let filters = SessionFilters::default().with_accepting_intents(true);
+    let get_command = GetSessionCommand::default().with_filters(filters);
+    let open_sessions = session_repo.get(&get_command).await.unwrap();
+
+    assert_eq!(open_sessions.len(), 1);
+    assert_eq!(open_sessions[0].name, "Open Session");
+    assert_eq!(open_sessions[0].accepting_intents, true);
+}
+
+#[sqlx::test]
+async fn test_update_session_name(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data = CreateSessionCommand::new(
+        table.id,
+        "Original Name".to_string(),
+        "A test session".to_string(),
+        true,
+    );
+
+    let created_session = session_repo.create(&session_data).await.unwrap();
+
+    let update_data = UpdateSessionCommand {
+        id: created_session.id,
+        name: Update::Change("Updated Name".to_string()),
+        description: Update::Keep,
+        accepting_intents: Update::Keep,
+    };
+
+    session_repo.update(&update_data).await.unwrap();
+
+    let updated_session = session_repo.find_by_id(&created_session.id).await.unwrap();
+
+    match updated_session {
+        Some(session) => {
+            assert_eq!(session.name, "Updated Name");
+            assert_eq!(session.description, "A test session".to_string());
+            assert_eq!(session.accepting_intents, true);
+        }
+        None => panic!("Session not found"),
+    }
+}
+
+#[sqlx::test]
+async fn test_update_session_description(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data = CreateSessionCommand::new(
+        table.id,
+        "Test Session".to_string(),
+        "Original description".to_string(),
+        true,
+    );
+
+    let created_session = session_repo.create(&session_data).await.unwrap();
+
+    let update_data = UpdateSessionCommand {
+        id: created_session.id,
+        name: Update::Keep,
+        description: Update::Change("Updated description".to_string()),
+        accepting_intents: Update::Keep,
+    };
+
+    session_repo.update(&update_data).await.unwrap();
+
+    let updated_session = session_repo.find_by_id(&created_session.id).await.unwrap();
+
+    match updated_session {
+        Some(session) => {
+            assert_eq!(session.name, "Test Session");
+            assert_eq!(session.description, "Updated description".to_string());
+        }
+        None => panic!("Session not found"),
+    }
+}
+
+#[sqlx::test]
+async fn test_update_session_accepting_intents(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data = CreateSessionCommand {
+        table_id: table.id,
+        name: "Test Session".to_string(),
+        description: "A test session".to_string(),
+        accepting_intents: true,
+    };
+
+    let created_session = session_repo.create(&session_data).await.unwrap();
+
+    let update_data = UpdateSessionCommand::new(
+        created_session.id,
+        Update::Keep,
+        Update::Keep,
+        Update::Change(false),
+    );
+
+    session_repo.update(&update_data).await.unwrap();
+
+    let updated_session = session_repo.find_by_id(&created_session.id).await.unwrap();
+
+    match updated_session {
+        Some(session) => {
+            assert_eq!(session.accepting_intents, false);
+        }
+        None => {
+            panic!("Session not found");
+        }
+    }
+}
+
+#[sqlx::test]
+async fn test_update_session_multiple_fields(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data = CreateSessionCommand::new(
+        table.id,
+        "Original Name".to_string(),
+        "Original description".to_string(),
+        true,
+    );
+
+    let created_session = session_repo.create(&session_data).await.unwrap();
+
+    let update_data = UpdateSessionCommand::new(
+        created_session.id,
+        Update::Change("New Name".to_string()),
+        Update::Change("New description".to_string()),
+        Update::Change(false),
+    );
+
+    session_repo.update(&update_data).await.unwrap();
+
+    let updated_session = session_repo.find_by_id(&created_session.id).await.unwrap();
+
+    match updated_session {
+        Some(session) => {
+            assert_eq!(session.name, "New Name");
+            assert_eq!(session.description, "New description".to_string());
+            assert_eq!(session.accepting_intents, false);
+        }
+        None => panic!("Session not found"),
+    }
+}
+
+#[sqlx::test]
+async fn test_update_session_not_found(pool: PgPool) {
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool));
+
+    let random_id = Uuid::new_v4();
+    let update_data = UpdateSessionCommand {
+        id: random_id,
+        name: Update::Change("New Name".to_string()),
+        description: Update::Keep,
+        accepting_intents: Update::Keep,
+    };
+
+    let result = session_repo.update(&update_data).await;
+
+    match result {
+        Err(Error::Repository(RepositoryError::NotFound)) => (),
+        _ => panic!("Unexpected error: {result:?}"),
+    }
+}
+
+#[sqlx::test]
+async fn test_delete_session(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let session_data = CreateSessionCommand::new(
+        table.id,
+        "Test Session".to_string(),
+        "A test session".to_string(),
+        true,
+    );
+
+    let created_session = session_repo
+        .create(&session_data)
+        .await
+        .expect("Failed to create session");
+
+    let delete_command = DeleteSessionCommand::new(created_session.id);
+
+    let deleted_session = session_repo
+        .delete(&delete_command)
+        .await
+        .expect("Failed to delete session");
+
+    assert_eq!(deleted_session.id, created_session.id);
+    assert_eq!(deleted_session.name, "Test Session");
+}
+
+#[sqlx::test]
+async fn test_delete_session_not_found(pool: PgPool) {
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool));
+
+    let random_id = Uuid::new_v4();
+    let delete_command = DeleteSessionCommand::new(random_id);
+
+    let result = session_repo.delete(&delete_command).await;
+
+    match result {
+        Err(Error::Repository(RepositoryError::NotFound)) => (),
+        _ => panic!("Unexpected error: {result:?}"),
+    }
+}
+
+#[sqlx::test]
+async fn test_concurrent_session_operations(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    let handles: Vec<_> = (0..5)
+        .map(|i| {
+            let pool = pool.clone();
+            let session_data = CreateSessionCommand::new(
+                table.id,
+                format!("Session {i}"),
+                format!("Description for session {i}"),
+                i % 2 == 0,
+            );
+            tokio::spawn(async move {
+                let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+                session_repo
+                    .create(&session_data)
+                    .await
+                    .expect("Failed to create session")
+            })
+        })
+        .collect();
+
+    let results: Vec<_> = futures::future::join_all(handles).await;
+
+    for result in results {
+        assert!(result.is_ok());
+    }
+
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let get_command = GetSessionCommand::default();
+    let all_sessions = session_repo
+        .get(&get_command)
+        .await
+        .expect("Failed to get all sessions");
+    assert_eq!(all_sessions.len(), 5);
+}
+
+#[sqlx::test]
+async fn test_pagination(pool: PgPool) {
+    let table_repo = PostgresTableRepository::new(Arc::new(pool.clone()));
+    let session_repo = PostgresSessionRepository::new(Arc::new(pool.clone()));
+    let gm = utils::create_user(&pool).await;
+    let game_system = utils::create_game_system(&pool).await;
+
+    let table_data = CreateTableCommand::new(
+        gm.id,
+        "Test Table".into(),
+        "A test table".into(),
+        Visibility::Public,
+        5,
+        game_system.id,
+    );
+    let table = table_repo.create(&table_data).await.unwrap();
+
+    // Create 25 sessions
+    for i in 0..25 {
+        let session_data = CreateSessionCommand::new(
+            table.id,
+            format!("Session {i}"),
+            format!("Description {i}"),
+            true,
+        );
+
+        session_repo
+            .create(&session_data)
+            .await
+            .expect("Failed to create session");
+    }
+
+    // Test first page (assuming default page size is 20)
+    let pagination = Pagination::default();
+    let get_command = GetSessionCommand::default().with_pagination(pagination);
+    let first_page = session_repo
+        .get(&get_command)
+        .await
+        .expect("Failed to get first page");
+    assert_eq!(first_page.len(), 20);
+
+    // Test second page
+    let pagination = Pagination::default().with_page(2);
+    let get_command = GetSessionCommand::default().with_pagination(pagination);
+    let second_page = session_repo
+        .get(&get_command)
+        .await
+        .expect("Failed to get second page");
+    assert_eq!(second_page.len(), 5);
+
+    // Test custom page size
+    let pagination = Pagination::default().with_page_size(10);
+    let get_command = GetSessionCommand::default().with_pagination(pagination);
+    let custom_page = session_repo
+        .get(&get_command)
+        .await
+        .expect("Failed to get custom page");
+    assert_eq!(custom_page.len(), 10);
+}

--- a/tests/table_repository_test.rs
+++ b/tests/table_repository_test.rs
@@ -450,7 +450,7 @@ async fn test_update_table_not_found(pool: PgPool) {
     let result = repo.update(&update_data).await;
 
     match result {
-        Err(Error::Repository(RepositoryError::TableNotFound)) => (),
+        Err(Error::Repository(RepositoryError::NotFound)) => (),
         _ => panic!("Unexpected error: {result:?}"),
     }
 }


### PR DESCRIPTION
This pull request introduces a new `session` domain module, including its core entity, commands, filters, repository, and service traits. Additionally, it improves the mapping of database constraint violations, particularly for session-related foreign keys, and enhances the infrastructure layer to support the new `session` domain.

**Session Domain Module Implementation:**

- Added the `session` domain module, including:
  - Entity definition for `Session` (`entity.rs`)
  - Command structs for creating, retrieving, updating, and deleting sessions (`commands.rs`)
  - Filter struct for querying sessions with various criteria (`filters.rs`)
  - Repository and service traits for session persistence and business logic (`repository.rs`, `services.rs`) [[1]](diffhunk://#diff-5045acb06cfb6e29811840fd8dcaa02d5e96266c7c1af2d205002264113cc402R1-R17) [[2]](diffhunk://#diff-75436ba6ce879d760ade2be5f59153649eec88003814cb2ff5f0cd89234a5107R1-R16)
  - Module exports in `mod.rs` for easy access
  - Registered the new module in the domain (`mod.rs`)

**Infrastructure Layer Enhancements:**

- Added conversion from the infrastructure `t_sessions::Model` to the domain `Session` entity, ensuring compatibility between layers (`t_sessions.rs`)
- Updated module exports in `entities/mod.rs` for consistent access to models
- Changed the prelude to export `PostgresSessionRepository` instead of the trait, aligning with other repositories (`prelude.rs`)

**Constraint Violation Mapping Improvements:**

- Refactored `map_constraint_violation` to accept a `DatabaseError` reference directly, improving error extraction and pattern matching
- Enhanced error extraction logic for various constraint patterns, added more descriptive debug and warning logs, and improved handling of session-related foreign key violations [[1]](diffhunk://#diff-8a83186f52a0b1208134e9eb2c6e2f4e9b253d995cbc2f4f4c10d1dd8e68a146L46-R87) [[2]](diffhunk://#diff-8a83186f52a0b1208134e9eb2c6e2f4e9b253d995cbc2f4f4c10d1dd8e68a146L58-R101) [[3]](diffhunk://#diff-8a83186f52a0b1208134e9eb2c6e2f4e9b253d995cbc2f4f4c10d1dd8e68a146L70-R118) [[4]](diffhunk://#diff-8a83186f52a0b1208134e9eb2c6e2f4e9b253d995cbc2f4f4c10d1dd8e68a146L82-R130) [[5]](diffhunk://#diff-8a83186f52a0b1208134e9eb2c6e2f4e9b253d995cbc2f4f4c10d1dd8e68a146L94-R144)